### PR TITLE
fix: PC表示改善と女医画像追加

### DIFF
--- a/docs/css/pc-layout-fix.css
+++ b/docs/css/pc-layout-fix.css
@@ -1,0 +1,468 @@
+/* PC Display Layout Fixes and Improvements */
+
+/* Desktop-specific improvements (min-width: 1024px) */
+@media (min-width: 1024px) {
+  /* Hero section improvements for PC */
+  .hero-content {
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  /* Fix doctor image positioning in hero */
+  .doctor-hero-container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 3rem;
+  }
+
+  .doctor-image-wrapper {
+    position: relative;
+    flex-shrink: 0;
+    width: 200px;
+    height: 200px;
+    background: linear-gradient(135deg, #ffffff 0%, #e0f2fe 100%);
+    border-radius: 50%;
+    padding: 20px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+    animation: float 6s ease-in-out infinite;
+  }
+
+  .doctor-image-wrapper::before {
+    content: "😊";
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    font-size: 24px;
+    background: #fbbf24;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 12px rgba(251, 191, 36, 0.4);
+  }
+
+  .doctor-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  .chatgpt-badge {
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);
+    color: white;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 14px;
+    font-weight: 600;
+    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+    white-space: nowrap;
+  }
+
+  /* Section spacing improvements */
+  section {
+    padding: 80px 0;
+  }
+
+  /* Pricing section layout fix */
+  #pricing .pricing-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  #pricing .pricing-card > div:first-child {
+    flex-shrink: 0;
+  }
+
+  #pricing .pricing-card > div:last-child {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  #pricing .pricing-card ul {
+    flex-grow: 1;
+  }
+
+  /* 10アカウント以上カードの高さ統一 */
+  #pricing .max-w-5xl {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+    align-items: stretch;
+  }
+
+  #pricing .max-w-5xl > div {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  /* Footer improvements */
+  footer .container {
+    max-width: 1200px;
+  }
+
+  footer .grid {
+    gap: 4rem;
+  }
+
+  /* CTA section centering */
+  #contact .md\\:flex {
+    display: flex;
+    flex-direction: column;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  #contact .md\\:w-1\\/2 {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  /* Button hover effects */
+  .btn {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .btn::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0;
+    height: 0;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.3);
+    transform: translate(-50%, -50%);
+    transition: width 0.6s, height 0.6s;
+  }
+
+  .btn:hover::after {
+    width: 300px;
+    height: 300px;
+  }
+
+  /* Timeline visual improvements */
+  .timeline-step {
+    padding: 2.5rem;
+    transition: all 0.3s ease;
+  }
+
+  .timeline-step:hover {
+    transform: scale(1.05);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  }
+
+  /* Feature cards equal height */
+  .feature-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  /* Trust banner spacing */
+  .trust-banner {
+    padding: 60px 0;
+  }
+
+  /* Navigation improvements */
+  header nav {
+    gap: 3rem;
+  }
+
+  /* Form layout improvements */
+  #contact form {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  #contact form > div {
+    margin-bottom: 0;
+  }
+
+  /* Hero text adjustments */
+  .hero-section h1 {
+    font-size: 4rem;
+    line-height: 1.1;
+    margin-bottom: 2rem;
+  }
+
+  .hero-section p {
+    font-size: 1.5rem;
+    line-height: 1.6;
+  }
+
+  /* Card shadow improvements */
+  .card {
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 30px 60px -15px rgba(0, 0, 0, 0.2);
+  }
+}
+
+/* Ultra-wide screen optimizations */
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1400px;
+  }
+
+  section {
+    padding: 100px 0;
+  }
+
+  .hero-section h1 {
+    font-size: 5rem;
+  }
+
+  .doctor-image-wrapper {
+    width: 250px;
+    height: 250px;
+  }
+}
+
+/* Fix overlapping issues */
+.relative {
+  position: relative;
+  z-index: 1;
+}
+
+.absolute {
+  z-index: 2;
+}
+
+/* Smooth scrolling for PC */
+@media (min-width: 1024px) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+/* PC-specific animations */
+@media (min-width: 1024px) and (prefers-reduced-motion: no-preference) {
+  .fade-in {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: all 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .fade-in.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  /* Parallax effect for hero background */
+  .hero-background {
+    transform: translateY(calc(var(--scroll) * 0.5));
+  }
+}
+
+/* Fix spacing issues at bottom */
+#contact {
+  margin-bottom: 0;
+}
+
+footer {
+  margin-top: 0;
+}
+
+/* Improve readability on large screens */
+@media (min-width: 1280px) {
+  p {
+    font-size: 1.125rem;
+    line-height: 1.75;
+  }
+
+  .text-sm {
+    font-size: 0.9375rem;
+  }
+}
+
+/* Fix pricing card height alignment */
+@media (min-width: 768px) {
+  .pricing-card,
+  .pricing-card.featured {
+    min-height: 650px;
+  }
+
+  /* Make the 10+ accounts card same height */
+  #pricing .bg-white.rounded-xl {
+    min-height: 650px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  #pricing .bg-white.rounded-xl .bg-primary-50 {
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  #pricing .bg-white.rounded-xl .p-6:last-child {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+}
+
+/* PC Navigation hover effects */
+@media (min-width: 1024px) {
+  header nav a:not(.btn) {
+    position: relative;
+    transition: color 0.3s ease;
+  }
+
+  header nav a:not(.btn)::after {
+    content: '';
+    position: absolute;
+    bottom: -4px;
+    left: 0;
+    width: 0;
+    height: 2px;
+    background: #60a5fa;
+    transition: width 0.3s ease;
+  }
+
+  header nav a:not(.btn):hover::after {
+    width: 100%;
+  }
+}
+
+/* Fix footer layout on PC */
+@media (min-width: 1024px) {
+  footer .grid {
+    grid-template-columns: 2fr repeat(3, 1fr);
+  }
+
+  footer h3 {
+    font-size: 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+
+  footer ul {
+    space-y: 0.75rem;
+  }
+}
+
+/* Mobile responsiveness for doctor image */
+@media (max-width: 1023px) {
+  .doctor-hero-container {
+    flex-direction: column;
+    text-align: center;
+    gap: 2rem;
+  }
+
+  .doctor-image-wrapper {
+    width: 150px;
+    height: 150px;
+    margin: 0 auto;
+  }
+
+  .chatgpt-badge {
+    font-size: 12px;
+    padding: 6px 12px;
+  }
+
+  .doctor-image-wrapper::before {
+    width: 30px;
+    height: 30px;
+    font-size: 18px;
+    bottom: 5px;
+    right: 5px;
+  }
+}
+
+/* Fix CTA section layout */
+#contact .max-w-4xl {
+  overflow: hidden;
+}
+
+#contact .md\:flex {
+  flex-direction: column;
+}
+
+@media (min-width: 768px) {
+  #contact .md\:flex {
+    flex-direction: row;
+  }
+  
+  #contact .md\:w-1\/2 {
+    width: 50%;
+  }
+}
+
+/* Improve pricing cards alignment */
+.pricing-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.pricing-card > div:first-child {
+  flex-shrink: 0;
+  min-height: 250px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.pricing-card > div:last-child {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.pricing-card ul {
+  flex-grow: 1;
+  margin-bottom: 2rem;
+}
+
+.pricing-card a {
+  margin-top: auto;
+}
+
+/* Fix 10+ accounts card */
+#pricing .bg-white.rounded-xl {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+#pricing .bg-white.rounded-xl .bg-primary-50 {
+  min-height: 250px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+#pricing .bg-white.rounded-xl .p-6:last-child {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+#pricing .bg-white.rounded-xl ul {
+  flex-grow: 1;
+  margin-bottom: 1.5rem;
+}
+
+#pricing .bg-white.rounded-xl a {
+  margin-top: auto;
+  width: 100%;
+  text-align: center;
+  padding: 0.75rem 1rem;
+}

--- a/docs/images/female-doctor.svg
+++ b/docs/images/female-doctor.svg
@@ -1,0 +1,43 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background circle -->
+  <circle cx="100" cy="100" r="95" fill="#E0F2FE" stroke="#3B82F6" stroke-width="2"/>
+  
+  <!-- Doctor body -->
+  <path d="M100 130C75 130 55 150 55 175V195H145V175C145 150 125 130 100 130Z" fill="#FFFFFF" stroke="#1E40AF" stroke-width="2"/>
+  
+  <!-- White coat collar -->
+  <path d="M85 135V145L100 150L115 145V135" fill="#FFFFFF" stroke="#1E40AF" stroke-width="2"/>
+  
+  <!-- Head/Face -->
+  <circle cx="100" cy="85" r="30" fill="#FDB5A6" stroke="#1E40AF" stroke-width="2"/>
+  
+  <!-- Hair -->
+  <path d="M70 75C70 60 80 50 100 50C120 50 130 60 130 75C130 75 125 65 100 65C75 65 70 75 70 75Z" fill="#4B5563"/>
+  <path d="M70 85C70 85 65 80 65 70C65 65 70 60 75 65C75 65 70 75 70 85Z" fill="#4B5563"/>
+  <path d="M130 85C130 85 135 80 135 70C135 65 130 60 125 65C125 65 130 75 130 85Z" fill="#4B5563"/>
+  
+  <!-- Eyes -->
+  <circle cx="88" cy="85" r="2" fill="#1F2937"/>
+  <circle cx="112" cy="85" r="2" fill="#1F2937"/>
+  
+  <!-- Smile -->
+  <path d="M90 95Q100 105 110 95" stroke="#1F2937" stroke-width="2" stroke-linecap="round" fill="none"/>
+  
+  <!-- Stethoscope -->
+  <path d="M100 130V140" stroke="#3B82F6" stroke-width="3"/>
+  <circle cx="100" cy="145" r="8" fill="#3B82F6"/>
+  <path d="M85 115C85 115 80 110 75 110C70 110 70 115 75 115C80 115 85 120 90 125" stroke="#3B82F6" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M115 115C115 115 120 110 125 110C130 110 130 115 125 115C120 115 115 120 110 125" stroke="#3B82F6" stroke-width="3" fill="none" stroke-linecap="round"/>
+  
+  <!-- Medical cross on coat -->
+  <rect x="85" y="155" width="30" height="30" rx="5" fill="#EF4444"/>
+  <path d="M95 165H105M100 160V170" stroke="white" stroke-width="3" stroke-linecap="round"/>
+  
+  <!-- ChatGPT device in hand -->
+  <rect x="125" y="150" width="25" height="35" rx="3" fill="#1F2937" stroke="#3B82F6" stroke-width="2"/>
+  <rect x="128" y="153" width="19" height="25" fill="#3B82F6"/>
+  <text x="137" y="168" font-family="Arial" font-size="8" fill="white" text-anchor="middle">AI</text>
+  
+  <!-- Hand holding device -->
+  <path d="M120 160C120 160 125 155 125 150L125 185C125 185 120 180 120 175" fill="#FDB5A6" stroke="#1E40AF" stroke-width="2"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,11 +10,13 @@
   <link rel="preload" href="css/modern-styles.css" as="style">
   <link rel="preload" href="css/aidma-colors.css" as="style">
   <link rel="preload" href="css/visibility-fix.css" as="style">
+  <link rel="preload" href="css/pc-layout-fix.css" as="style">
   
   <!-- Load CSS files -->
   <link rel="stylesheet" href="css/modern-styles.css">
   <link rel="stylesheet" href="css/aidma-colors.css">
   <link rel="stylesheet" href="css/visibility-fix.css">
+  <link rel="stylesheet" href="css/pc-layout-fix.css">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -103,10 +105,18 @@
             <span class="text-white/90 text-sm">48時間以内に利用開始可能</span>
           </div>
           
-          <h1 class="text-4xl md:text-5xl lg:text-6xl font-display font-bold text-white mb-6 leading-tight">
-            医療現場のための<br>
-            <span class="gradient-text typing-animation" data-text="ChatGPT Plus" data-speed="150"></span>
-          </h1>
+          <div class="doctor-hero-container">
+            <div class="doctor-image-wrapper">
+              <img src="images/female-doctor.svg" alt="笑顔の女医がChatGPTを持っている" class="doctor-image">
+              <div class="chatgpt-badge">ChatGPT</div>
+            </div>
+            <div>
+              <h1 class="text-4xl md:text-5xl lg:text-6xl font-display font-bold text-white mb-6 leading-tight">
+                医療現場のための<br>
+                <span class="gradient-text typing-animation" data-text="ChatGPT Plus" data-speed="150"></span>
+              </h1>
+            </div>
+          </div>
           
           <p class="text-xl md:text-2xl text-gray-300 mb-8 leading-relaxed">
             クレジットカード不要、<span class="text-white font-semibold">請求書払い</span>で即導入。<br>
@@ -1000,8 +1010,8 @@
   <!-- フッター -->
   <footer class="bg-primary-900 text-gray-400 py-12">
     <div class="container mx-auto px-4">
-      <div class="grid md:grid-cols-4 gap-8">
-        <div>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+        <div class="lg:col-span-1">
           <h3 class="text-xl font-bold text-white mb-4">ChatGPT Plus<br>医療機関向け</h3>
           <p class="text-sm">医療現場のAI活用を促進し、業務効率化を実現するアカウント管理代行サービス</p>
         </div>
@@ -1017,9 +1027,9 @@
         <div>
           <h4 class="text-lg font-medium text-white mb-4">リンク</h4>
           <ul class="space-y-2">
-            <li><a href="#purpose" class="hover:text-white transition-colors">目的</a></li>
-            <li><a href="#flow" class="hover:text-white transition-colors">導入フロー</a></li>
-            <li><a href="#price" class="hover:text-white transition-colors">料金</a></li>
+            <li><a href="#benefits" class="hover:text-white transition-colors">導入メリット</a></li>
+            <li><a href="#workflow" class="hover:text-white transition-colors">業務フロー</a></li>
+            <li><a href="#pricing" class="hover:text-white transition-colors">料金プラン</a></li>
             <li><a href="#faq" class="hover:text-white transition-colors">よくある質問</a></li>
           </ul>
         </div>


### PR DESCRIPTION
- タイトル横に笑顔の女医がChatGPTを持つSVG画像を配置
- PC表示用の新しいCSS（pc-layout-fix.css）を追加
- 価格カードの高さを統一化
- フッターを4列レイアウトに改善
- CTAセクションを中央配置に変更
- ボタンにリップルエフェクト追加
- レスポンシブデザインを最適化